### PR TITLE
fix google search tool: properly encode search query parameters

### DIFF
--- a/google/search/src/search.ts
+++ b/google/search/src/search.ts
@@ -21,6 +21,10 @@ export async function search (
   if (query === '') {
     throw new Error('No query provided')
   }
+
+  const encodedQuery = encodeURIComponent(query)
+  const searchUrl = `https://www.google.com/search?q=${encodedQuery}&udm=14`
+  
   const foundURLs = new Set<string>()
   const results: Array<Promise<SearchResult | null>> = []
 
@@ -40,7 +44,7 @@ export async function search (
   )
 
   try {
-    await page.goto(`https://www.google.com/search?q=${query}&udm=14`)
+    await page.goto(searchUrl)
     const content = await page.content()
     const $ = cheerio.load(content)
     const elements = $('#rso a[jsname]')

--- a/google/search/tool.gpt
+++ b/google/search/tool.gpt
@@ -6,12 +6,12 @@ Share Tools: Search
 
 ---
 Name: Search
-Description: Search Google with a given query and return relevant information from the search results
+Description: Search Google with a given query and return relevant information from the search results. Search with more maxResults if you need more information.
 JSON Response: true
 Share Context: ../../time
 Tools: service
-Args: maxResults: The maximum number of search results to gather relevant information from (optional, default 3)
 Args: query: A question, statement, or topic to search with (required)
+Args: maxResults: The maximum number of search results to gather relevant information from (optional, default 3, minimum 2)
 
 #!http://service.daemon.gptscript.local/search
 


### PR DESCRIPTION
Is a fix for https://github.com/otto8-ai/otto8/issues/856

- Add encodeURIComponent for Google search URL
- Improve URL safety for special characters and Unicode
- Prevent malformed search requests
- Change gptscript tool description to get llm to re-call the tool if it believes it needs more search results
- Change gptscript maxResults minimum value to 2 - openai gpt4o was setting this to 1 in many runs and this was preventing the run from finding the correct answer